### PR TITLE
Updated resume link on work page

### DIFF
--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -2,9 +2,10 @@ import cx from 'clsx'
 import {
   ArrowLeftIcon,
   ArrowTopRightIcon,
-  LinkedInLogoIcon,
+  DownloadIcon,
+  FileTextIcon,
   GitHubLogoIcon,
-  FileTextIcon
+  LinkedInLogoIcon
 } from '@radix-ui/react-icons'
 
 import { Dribbble, Mastodon } from './src'
@@ -14,6 +15,7 @@ const IconMap = {
   'arrow-top-right': ArrowTopRightIcon,
   document: FileTextIcon,
   dribbble: Dribbble,
+  download: DownloadIcon,
   github: GitHubLogoIcon,
   linkedin: LinkedInLogoIcon,
   mastodon: Mastodon

--- a/src/pages/work.md
+++ b/src/pages/work.md
@@ -69,9 +69,11 @@ description: Design samples and experience
 
 {% details heading="Learning React, Next.js and Storybook" subheading="2018 - Present" meta="So far so good..." /%}
 
+{% block as="div" className="block-callout" icon="dribbble" %}
 {% social
   className="resume"
-  icon="document"
-  name="View Resume"
+  icon="download"
+  name="Download resume (PDF)"
   url="/assets/resume-jason-melgoza-2024.pdf"
 /%}
+{% /block %}


### PR DESCRIPTION
Fix incorrect import of LinkedInLogoIcon, add DownloadIcon and FileTextIcon and update block  to use 'download' icon instead of 'document'