### PR TITLE
Replace email copy button with Cal.com meeting link

### DIFF
--- a/markdoc/tags/button.markdoc.js
+++ b/markdoc/tags/button.markdoc.js
@@ -4,7 +4,7 @@ export default {
   render: Button,
   attributes: {
     className: { type: String },
-    email: { type: String },
+    href: { type: String },
     text: { type: String }
   }
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,29 +1,18 @@
-import React, { useState } from 'react'
+import React from 'react'
 import cx from 'clsx'
 import styles from './Button.module.css'
 
-export default function Button({ className, email, text }) {
-  const [buttonText, setButtonText] = useState(text)
-
-  const handleCopyEmail = async () => {
-    if (!navigator.clipboard) {
-      console.error('Clipboard API not available')
-      return
-    }
-    try {
-      await navigator.clipboard.writeText(email)
-      setButtonText('Email copied!')
-      setTimeout(() => setButtonText(text), 2500) // Reset text after 2.5 seconds
-    } catch (err) {
-      console.error('Failed to copy text: ', err)
-    }
-  }
-
+export default function Button({ className, href, text }) {
   return (
     <div className={styles.container}>
-      <button className={cx(styles.root, className)} onClick={handleCopyEmail}>
-        <span className='button-text'>{buttonText}</span>
-      </button>
+      <a
+        className={cx(styles.root, className)}
+        href={href}
+        target='_blank'
+        rel='noopener noreferrer'
+      >
+        <span className='button-text'>{text}</span>
+      </a>
     </div>
   )
 }

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -36,7 +36,7 @@ export default function Footer() {
             <p>Have a project in mind? I'd love to hear about it.</p>
           </div>
           <Box className='contact-button'>
-            <Button text={"Let's Chat"} email='jasonmelgoza@gmail.com' />
+            <Button text={"Let's Chat"} href='https://cal.com/jason-melgoza/30min' />
           </Box>
           <AsciiNoiseEffect className='contact-background' />
         </div>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -10,7 +10,7 @@ Product designer based in California, crafting interfaces and chasing the next w
 
 A design systems specialist with over 10 years of experience in product design — currently at [Bill](https://www.bill.com/), helping build the foundation that keeps product teams moving forward.
 
-{% button text="Let's Talk" email="jasonmelgoza@gmail.com" className="contact" /%}
+{% button text="Let's Talk" href="https://cal.com/jason-melgoza/30min" className="contact" /%}
 
 {% /block %}
 {% block className="work" id="work" %}


### PR DESCRIPTION
Swaps the clipboard email behavior for a direct link to the Cal scheduling page, opening in a new tab.