### PR TITLE
Fix button link styles being overridden by document prose rules

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -37,6 +37,7 @@
   font-weight: 500;
   line-height: 18px;
   color: #FFF;
+  text-decoration: none;
   letter-spacing: -0.09px;
 }
 

--- a/src/components/Document/Document.module.css
+++ b/src/components/Document/Document.module.css
@@ -49,13 +49,15 @@
   border: 1px solid var(--gray-a3);
 }
 
-.root a {
+.root p a,
+.root li a {
   font-weight: 550;
   color: var(--fg);
   text-decoration: underline;
 }
 
-.root a:hover {
+.root p a:hover,
+.root li a:hover {
   color: var(--red-9)
 }
 


### PR DESCRIPTION
## Summary

- Scoped `Document.module.css` link styles to `.root p a` and `.root li a` so they no longer bleed into the Button component
- Added explicit `text-decoration: none` to `Button.module.css` as a safeguard

## Test plan

- [x] Confirm the "Let's Talk" button in the secondary section renders white text with no underline
- [x] Confirm inline content links in paragraphs and lists still render with underline and correct color
- [x] Confirm the footer "Let's Chat" button is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)